### PR TITLE
Building docker images from the release server

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -107,7 +107,7 @@ function main {
 
 		mkdir -p ${release_dir}
 
-		curl -o ${release_dir}/${release_file_name} ${release_file_url}
+		curl -f -o ${release_dir}/${release_file_name} ${release_file_url}
 	fi
 
 	if [[ ${release_file_name} == *.7z ]]

--- a/build_image.sh
+++ b/build_image.sh
@@ -88,6 +88,7 @@ function main {
 	release_dir=${release_dir#*com/}
 	release_dir=${release_dir#*com/}
 	release_dir=${release_dir#*private/ee/}
+	release_dir=${release_dir#*liferay-release-tool/}
 	release_dir=releases/${release_dir}
 
 	local release_file_name=${1##*/}

--- a/build_image.sh
+++ b/build_image.sh
@@ -212,6 +212,12 @@ function main {
 
 	release_version=${release_version##*/}
 
+	if [[ ${release_file_url} == http://release* ]]
+	then
+		release_version=${release_file_url#*tomcat-}
+		release_version=${release_version%.*}
+	fi
+
 	local label_version=${release_version}
 
 	if [[ ${release_file_url%} == */snapshot-* ]]

--- a/build_image.sh
+++ b/build_image.sh
@@ -94,7 +94,7 @@ function main {
 
 	local release_file_url=${1}
 
-	if [[ ${release_file_url} != http://mirrors.lax.liferay.com* ]]
+	if [[ ${release_file_url} != http://mirrors.*.liferay.com* ]]
 	then
 		release_file_url=http://mirrors.lax.liferay.com/${release_file_url}
 	fi

--- a/build_image.sh
+++ b/build_image.sh
@@ -94,7 +94,7 @@ function main {
 
 	local release_file_url=${1}
 
-	if [[ ${release_file_url} != http://mirrors.*.liferay.com* ]]
+	if [[ ${release_file_url} != http://mirrors.*.liferay.com* ]] && [[ ${release_file_url} != http://release* ]]
 	then
 		release_file_url=http://mirrors.lax.liferay.com/${release_file_url}
 	fi

--- a/build_image.sh
+++ b/build_image.sh
@@ -203,6 +203,11 @@ function main {
 		docker_image_name=${docker_image_name}-snapshot
 	fi
 
+	if [[ ${release_file_url} == http://release* ]]
+	then
+		docker_image_name=${docker_image_name}-pre-release
+	fi
+
 	local release_version=${release_file_url%/*}
 
 	release_version=${release_version##*/}

--- a/build_image.sh
+++ b/build_image.sh
@@ -108,14 +108,14 @@ function main {
 
 		mkdir -p ${release_dir}
 
-		curl -f -o ${release_dir}/${release_file_name} ${release_file_url}
+		curl -f -o ${release_dir}/${release_file_name} ${release_file_url} || exit 2
 	fi
 
 	if [[ ${release_file_name} == *.7z ]]
 	then
-		7z x -O${timestamp} ${release_dir}/${release_file_name}
+		7z x -O${timestamp} ${release_dir}/${release_file_name} || exit 3
 	else
-		unzip -q ${release_dir}/${release_file_name} -d ${timestamp}
+		unzip -q ${release_dir}/${release_file_name} -d ${timestamp}  || exit 3
 	fi
 
 	mv ${timestamp}/liferay-* ${timestamp}/liferay


### PR DESCRIPTION
These changes allow us to build docker images before they are released based on SP and fix pack bundle images. If the release server is the source, it's the liferay/*-pre-release repository (for dxp it will be liferay/dxp-pre-release).