### PR TITLE
nss is needed for Patching Tool to run

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -41,7 +41,7 @@ LABEL org.label-schema.vcs-url="https://github.com/liferay/liferay-docker"
 LABEL org.label-schema.vendor="Liferay, Inc."
 LABEL org.label-schema.version="${LABEL_VERSION}"
 
-RUN apk add bash curl tomcat-native tree ttf-dejavu
+RUN apk add bash curl nss tomcat-native tree ttf-dejavu
 
 USER liferay:liferay
 


### PR DESCRIPTION
Small change to make Patching Tool work. Next up: cutting container size by 30-50%, speeding up hotfix installation by roughly 75%, automating hotfix installation.