### PR TITLE
Configs revert

### DIFF
--- a/template/scripts/configure_liferay.sh
+++ b/template/scripts/configure_liferay.sh
@@ -15,7 +15,6 @@ function main {
 			echo ""
 
 			ls ${LIFERAY_MOUNT_DIR}/configs/portal-*.properties
-
 			cp ${LIFERAY_MOUNT_DIR}/configs/portal-*.properties ${LIFERAY_HOME}
 
 			echo ""
@@ -27,7 +26,6 @@ function main {
 			echo ""
 
 			ls ${LIFERAY_MOUNT_DIR}/configs/*.c*f*g
-
 			cp ${LIFERAY_MOUNT_DIR}/configs/*.c*f*g ${LIFERAY_HOME}/osgi/configs
 
 			echo ""

--- a/template/scripts/configure_liferay.sh
+++ b/template/scripts/configure_liferay.sh
@@ -7,34 +7,6 @@ function main {
 		echo ""
 	fi
 
-	if [ -d ${LIFERAY_MOUNT_DIR}/configs ]
-	then
-		if [[ $(ls -A ${LIFERAY_MOUNT_DIR}/configs/portal-*.properties) ]]
-		then
-			echo "[LIFERAY] Copying configuration files from ${LIFERAY_MOUNT_DIR}/configs into ${LIFERAY_HOME}:"
-			echo ""
-
-			ls ${LIFERAY_MOUNT_DIR}/configs/portal-*.properties
-			cp ${LIFERAY_MOUNT_DIR}/configs/portal-*.properties ${LIFERAY_HOME}
-
-			echo ""
-		fi
-
-		if [[ $(ls -A ${LIFERAY_MOUNT_DIR}/configs/*.c*f*g) ]]
-		then
-			echo "[LIFERAY] Copying configuration files from ${LIFERAY_MOUNT_DIR}/configs into ${LIFERAY_HOME}/osgi/configs:"
-			echo ""
-
-			ls ${LIFERAY_MOUNT_DIR}/configs/*.c*f*g
-			cp ${LIFERAY_MOUNT_DIR}/configs/*.c*f*g ${LIFERAY_HOME}/osgi/configs
-
-			echo ""
-		fi
-	else
-		echo "[LIFERAY] The directory /mnt/liferay/configs does not exist. Create the directory \$(pwd)/xyz123/configs on the host operating system to create the directory ${LIFERAY_MOUNT_DIR}/configs on the container. Files in ${LIFERAY_MOUNT_DIR}/configs will be copied to ${LIFERAY_HOME} of ${LIFERAY_HOME}/osgi/configs (based on their type) before ${LIFERAY_PRODUCT_NAME} starts."
-		echo ""
-	fi
-
 	if [ -d ${LIFERAY_MOUNT_DIR}/files ]
 	then
 		if [[ $(ls -A ${LIFERAY_MOUNT_DIR}/files) ]]


### PR DESCRIPTION
Hey Brian,

I'm sorry for reverting my code after you have reviewed. @arbetts had a good point on my PR which I haven't noticed in time. The configs name is used by Workspace for a slightly different structure and meaning so it would be confusing for all developers using Workspace and would lead to a lot of confusion. Not allowing the confusion to happen weighs more than having this minor feature in.

