### PR TITLE
We need to allow scripts to set environment variables. Exec permissio…

### DIFF
--- a/template/scripts/_liferay_common.sh
+++ b/template/scripts/_liferay_common.sh
@@ -10,12 +10,7 @@ function execute_scripts {
 			echo ""
 			echo "[LIFERAY] Executing ${SCRIPT_NAME}."
 
-			if [ ! -x ${1}/${SCRIPT_NAME} ]
-			then
-				chmod a+x ${1}/${SCRIPT_NAME}
-			fi
-
-			${1}/${SCRIPT_NAME}
+			source ${1}/${SCRIPT_NAME}
 		done
 
 		echo ""


### PR DESCRIPTION
…n is not needed when a script is sourced, this is why it's simplified