### PR TITLE
[#35] Fix "connection reset" error when attaching the debugger to the…

### DIFF
--- a/template/scripts/start_liferay.sh
+++ b/template/scripts/start_liferay.sh
@@ -7,6 +7,7 @@ function main {
 
 	if [ "${LIFERAY_JPDA_ENABLED}" == "true" ]
 	then
+		export JPDA_ADDRESS=8000
 		${LIFERAY_HOME}/tomcat/bin/catalina.sh jpda run
 	else
 		${LIFERAY_HOME}/tomcat/bin/catalina.sh run


### PR DESCRIPTION
… container

Hi Brian, I'm helping Zsolt to enable support coverage for docker images. I've found liferay#35 which prevents devs to attach a debugger to the container even if we map the port and set the env var to launch tomcat with jpda.

We need to override the default JPDA_ADDRESS value to remove the host part, leaving just the port.
To avoid users to do this manually, we can set this just before starting tomcat with jpda.

Best