### PR TITLE
LPS-110722 Link directories from /opt/liferay to /home/liferay

### DIFF
--- a/template/Dockerfile
+++ b/template/Dockerfile
@@ -15,6 +15,8 @@ RUN adduser -D -h /home/liferay liferay && addgroup liferay liferay
 COPY --chown=liferay:liferay home/.bashrc /home/liferay/
 COPY --chown=liferay:liferay liferay /opt/liferay
 
+RUN ln -fs /opt/liferay/* /home/liferay
+
 ENTRYPOINT /usr/local/bin/liferay_entrypoint.sh
 
 ENV JAVA_VERSION=zulu8


### PR DESCRIPTION
We verified, it cannot be done in one RUN as the lines below are copying the files which would be linked. We addressed your other concern about the training /.