### PR TITLE
Docker image versioning

### DIFF
--- a/.releng/docker-image.changelog
+++ b/.releng/docker-image.changelog
@@ -1,0 +1,20 @@
+#
+# Liferay Docker Image Version 0.0.1
+#
+
+docker.image.change.log-0.0.1=LPS-110522 LPS-114768 LPS-110722 LPS-112716 LPS-112893 LPS-112892 LPS-110737 LPS-110963 LPS-110737 LPS-110732 LPS-110696 LPS-86891
+docker.image.git.id-0.0.1=fe95dd75543877d9bd78cb8238b07c5b2207ea5b
+
+#
+# Liferay Docker Image Version 0.0.2
+#
+
+docker.image.change.log-0.0.2=LPS-110722
+docker.image.git.id-0.0.2=21767d3dad1be3aae2a9cae8757ac83037f3f433
+
+#
+# Liferay Docker Image Version 0.0.3
+#
+
+docker.image.change.log-0.0.3=LPS-116335
+docker.image.git.id-0.0.3=39a75cc32629940cdd0b656f1ab3d765bead7b00

--- a/build_all_images.sh
+++ b/build_all_images.sh
@@ -217,6 +217,11 @@ function build_images_dxp_72 {
 }
 
 function main {
+	if [ "${BUILD_ALL_IMAGES_PUSH}" == "push" ] && ! ./release_notes.sh fail-on-change
+	then
+		exit 1
+	fi
+
 	LOGS_DIR=logs-$(date "$(date)" "+%Y%m%d%H%M")
 
 	mkdir -p ${LOGS_DIR}

--- a/build_image.sh
+++ b/build_image.sh
@@ -104,6 +104,8 @@ function build_docker_image {
 		release_version=${LIFERAY_DOCKER_RELEASE_VERSION}
 	fi
 
+	local docker_image_version=$(./release_notes.sh get-version)
+
 	DOCKER_IMAGE_TAGS=()
 
 	local default_ifs=${IFS}
@@ -118,7 +120,9 @@ function build_docker_image {
 			DOCKER_IMAGE_TAGS+=("liferay/${docker_image_name}:${release_branch}-$(date "${CURRENT_DATE}" "+%Y%m%d")")
 			DOCKER_IMAGE_TAGS+=("liferay/${docker_image_name}:${release_branch}")
 		else
+			DOCKER_IMAGE_TAGS+=("liferay/${docker_image_name}:${release_version_single}-d${docker_image_version}-${TIMESTAMP}")
 			DOCKER_IMAGE_TAGS+=("liferay/${docker_image_name}:${release_version_single}-${TIMESTAMP}")
+			DOCKER_IMAGE_TAGS+=("liferay/${docker_image_name}:${release_version_single}-d${docker_image_version}")
 			DOCKER_IMAGE_TAGS+=("liferay/${docker_image_name}:${release_version_single}")
 		fi
 	done

--- a/release_notes.sh
+++ b/release_notes.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+source ./_common.sh
+
+function check_usage {
+	check_utils git sed sort tr
+}
+
+function generate_release_notes {
+	CURRENT_SHA=$(git log -1 --pretty=%H)
+	CHANGELOG=$(git log --pretty=%s --grep "^LPS-" ${LATEST_SHA}..${CURRENT_SHA} | sed -e "s/\ .*/ /" | uniq | tr -d "\n" | tr -d "\r" | sed -e "s/ $//")
+
+	if [ -n "${CHANGELOG}" ]
+	then
+		VERSION_MICRO=$(($VERSION_MICRO+1))
+
+		(
+			echo ""
+			echo "#"
+			echo "# Liferay Docker Image Version ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_MICRO}"
+			echo "#"
+			echo ""
+			echo "docker.image.change.log-${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_MICRO}=${CHANGELOG}"
+			echo "docker.image.git.id-${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_MICRO}=${CURRENT_SHA}"
+		) >> .releng/docker-image.changelog
+	fi
+}
+
+function get_latest_version {
+	local git_line=$(cat .releng/docker-image.changelog | grep docker.image.git.id | tail -n1)
+
+	LATEST_SHA=${git_line#*=}
+	LATEST_VERSION=${git_line#*-}
+	LATEST_VERSION=${LATEST_VERSION%=*}
+
+	VERSION_MAJOR=${LATEST_VERSION%%.*}
+	VERSION_MINOR=${LATEST_VERSION#*.}
+	VERSION_MINOR=${VERSION_MINOR%.*}
+	VERSION_MICRO=${LATEST_VERSION##*.}
+}
+
+function main {
+	check_usage ${@}
+
+	get_latest_version
+
+	generate_release_notes
+}
+
+main ${@}

--- a/release_notes.sh
+++ b/release_notes.sh
@@ -3,6 +3,20 @@
 source ./_common.sh
 
 function check_usage {
+	if [ ! -n "${1}" ]
+	then
+		echo "Usage: ${0} <command>"
+		echo ""
+		echo "This script requires the first parameter to be set to one of these options:"
+		echo ""
+		echo "    commit: Writes and commits the necessary version change with the changelog"
+		echo "    fail-on-change: The script will return an error code if there was a version number changing commit since the last release notes change"
+		echo "    get-version: Returns the current version number"
+		echo "    anything else: Display the required version number change"
+
+		exit 1
+	fi
+
 	check_utils git sed sort tr
 }
 
@@ -26,18 +40,18 @@ function generate_release_notes {
 
 		echo "Version bump from ${LATEST_VERSION} to ${NEW_VERSION}"
 
-		(
-			echo ""
-			echo "#"
-			echo "# Liferay Docker Image Version ${NEW_VERSION}"
-			echo "#"
-			echo ""
-			echo "docker.image.change.log-${NEW_VERSION}=${CHANGELOG}"
-			echo "docker.image.git.id-${NEW_VERSION}=${CURRENT_SHA}"
-		) >> .releng/docker-image.changelog
-
 		if [ "${1}" == "commit" ]
 		then
+			(
+				echo ""
+				echo "#"
+				echo "# Liferay Docker Image Version ${NEW_VERSION}"
+				echo "#"
+				echo ""
+				echo "docker.image.change.log-${NEW_VERSION}=${CHANGELOG}"
+				echo "docker.image.git.id-${NEW_VERSION}=${CURRENT_SHA}"
+			) >> .releng/docker-image.changelog
+
 			git add .releng/docker-image.changelog
 			git commit -m "${NEW_VERSION} changelog"
 		fi
@@ -67,12 +81,18 @@ function get_latest_version {
 	VERSION_MINOR=${LATEST_VERSION#*.}
 	VERSION_MINOR=${VERSION_MINOR%.*}
 	VERSION_MICRO=${LATEST_VERSION##*.}
+
+	if [ "${1}" == "get-version" ]
+	then
+		echo ${LATEST_VERSION}
+		exit
+	fi
 }
 
 function main {
 	check_usage ${@}
 
-	get_latest_version
+	get_latest_version ${@}
 
 	get_changelog ${@}
 

--- a/release_notes.sh
+++ b/release_notes.sh
@@ -9,12 +9,12 @@ function check_usage {
 function generate_release_notes {
 	if [ -n "${CHANGELOG}" ]
 	then
-		if ( git log --pretty=%s --grep "#majorchange" ${LATEST_SHA}..${CURRENT_SHA} >/dev/null )
+		if ( git log --pretty=%s ${LATEST_SHA}..${CURRENT_SHA} | grep "#majorchange" > /dev/null )
 		then
 			VERSION_MAJOR=$(($VERSION_MAJOR+1))
 			VERSION_MINOR=0
 			VERSION_MICRO=0
-		elif ( git log --pretty=%s --grep "#minorchange" ${LATEST_SHA}..${CURRENT_SHA} >/dev/null )
+		elif ( git log --pretty=%s ${LATEST_SHA}..${CURRENT_SHA} | grep "#minorchange" > /dev/null )
 		then
 			VERSION_MINOR=$(($VERSION_MINOR+1))
 			VERSION_MICRO=0

--- a/release_notes.sh
+++ b/release_notes.sh
@@ -66,6 +66,7 @@ function get_changelog {
 	then
 		echo "There was a change in the repository which requires regenerating the release notes."
 		echo "Run \"./release_notes.sh commit\" to commit the updated changelog."
+
 		exit 1
 	fi
 }
@@ -85,6 +86,7 @@ function get_latest_version {
 	if [ "${1}" == "get-version" ]
 	then
 		echo ${LATEST_VERSION}
+
 		exit
 	fi
 }


### PR DESCRIPTION
I have found a way to version the docker images which would enable us to provide proper change log for our customers. I have been trying to copy the system from various .releng files, however it was not clearly applicable.

Once this change is merged, this is the way you will be able to publish new docker images:
    ./release_notes.sh commit # This will commit the version number changes if necessary
    # Here use the script which would push the code to github
    ./build_all_images.sh push

The version increases are automatic and it only happens when there's an LPS ticket in the latest commit messages. If we make important changes, please require an LPS ticket from now on - this would enable us to have proper release notes.

If one of the commit messages since the last version contain "#majorchange" it will increase the first digit. The first build will do that as with this LPS I finally wanted to enter into the 1.0.0 zone. If "#minorchange" is added, the second digit will increase. Micro is automatic, if LPS was committed since.

If there was no LPS ticket in the commits since the last build it won't bump the version number so we can safely add new images without preparing new release notes.

Changelog and change log are not consistently used in the liferay-portal-ee repo, however as wikipedia uses "changelog" I was using it here.