### PR TITLE
LPS-128464 Propagating license failure to the build_all script. tee s…

### DIFF
--- a/build_all_images.sh
+++ b/build_all_images.sh
@@ -66,13 +66,27 @@ function build_bundle_image {
 	{
 		LIFERAY_DOCKER_FIX_PACK_URL=${3} LIFERAY_DOCKER_RELEASE_FILE_URL=${2} LIFERAY_DOCKER_RELEASE_VERSION=${1} LIFERAY_DOCKER_TEST_HOTFIX_URL=${5} LIFERAY_DOCKER_TEST_INSTALLED_PATCHES=${4} time ./build_bundle_image.sh ${BUILD_ALL_IMAGES_PUSH} 2>&1
 
-		if [ $? -gt 0 ]
+		local build_bundle_image_exit_code=$?
+
+		if [ ${build_bundle_image_exit_code} -gt 0 ]
 		then
 			echo "FAILED: ${build_id}" >> ${LOGS_DIR}/results
+
+			if [ ${build_bundle_image_exit_code} -eq 4 ]
+			then
+				echo "License failure while building image ${build_id}." > ${LOGS_DIR}/license-failure
+			fi
 		else
 			echo "SUCCESS: ${build_id}" >> ${LOGS_DIR}/results
 		fi
 	} | tee ${LOGS_DIR}/${build_id}".log"
+
+	if [ -e ${LOGS_DIR}/license-failure ]
+	then
+		echo "Existing as there was a license failure."
+
+		exit 4
+	fi
 }
 
 function build_bundle_images_dxp_70 {

--- a/build_bundle_image.sh
+++ b/build_bundle_image.sh
@@ -159,7 +159,10 @@ function check_usage {
 function download_trial_dxp_license {
 	rm -fr ${TEMP_DIR}/liferay/data/license
 
-	./download_trial_dxp_license.sh ${TEMP_DIR}/liferay $(date "${CURRENT_DATE}" "+%s000") ${RELEASE_FILE_NAME}
+	if ( ! ./download_trial_dxp_license.sh ${TEMP_DIR}/liferay $(date "${CURRENT_DATE}" "+%s000") ${RELEASE_FILE_NAME} )
+	then
+		exit 4
+	fi
 }
 
 function install_fix_pack {


### PR DESCRIPTION
…wallows all exit codes, this is the reason for the file based communication