### PR TITLE
LPS-132771 Add FFMPEG and Gifsicle binaries to the official Docker image

### DIFF
--- a/templates/base/Dockerfile
+++ b/templates/base/Dockerfile
@@ -6,7 +6,7 @@ ARG LABEL_VCS_REF
 ARG LABEL_VCS_URL
 ARG LABEL_VERSION
 
-RUN apk --no-cache add bash curl ghostscript imagemagick nss tomcat-native tree ttf-dejavu zulu11-jdk=11.0.5-r3
+RUN apk --no-cache add bash curl ffmpeg ghostscript gifsicle imagemagick nss tomcat-native tree ttf-dejavu zulu11-jdk=11.0.5-r3
 RUN apk --no-cache upgrade
 
 COPY scripts/* /usr/local/bin/


### PR DESCRIPTION
Tested and working on a Dockerized bundle (current master).