### PR TITLE
DOCKER-43 unzip is not part of the default ubuntu image

### DIFF
--- a/templates/base/Dockerfile
+++ b/templates/base/Dockerfile
@@ -7,7 +7,7 @@ ARG LABEL_VCS_URL
 ARG LABEL_VERSION
 
 RUN apt update && \
-	apt install -y bash curl ffmpeg ghostscript gifsicle imagemagick libnss3 libtcnative-1 telnet tree ttf-dejavu zulu11-jdk=11.0.12-1 && \
+	apt install -y bash curl ffmpeg ghostscript gifsicle imagemagick libnss3 libtcnative-1 telnet tree ttf-dejavu unzip zulu11-jdk=11.0.12-1 && \
 	apt upgrade -y && \
 	apt clean
 


### PR DESCRIPTION
This is related to a support issue, please publish all 7.3 DXPs after this fix is merged. If there's bandwidth, please republish all DXPs, but it's not a must (the chance of need for an update for 2.x Patching Tool is way lower).

Thank you,
Zsolt