### PR TITLE
DOCKER-65 SIGTERM is not propogated to the DXP process so Graceful sh…

### DIFF
--- a/templates/base/scripts/liferay_entrypoint.sh
+++ b/templates/base/scripts/liferay_entrypoint.sh
@@ -3,7 +3,11 @@
 source /usr/local/bin/_liferay_common.sh
 
 function handle_kill_TERM {
-	kill -TERM ${START_LIFERAY_PID}
+	exec 5<>/dev/tcp/localhost/8005 && echo "SHUTDOWN" >&5
+
+	if [ $? -gt 0 ]; then
+		kill -TERM ${START_LIFERAY_PID}
+	fi
 }
 
 function main {

--- a/templates/bundle/Dockerfile
+++ b/templates/bundle/Dockerfile
@@ -12,7 +12,7 @@ COPY --chown=liferay:liferay liferay /opt/liferay
 
 RUN ln -fs /opt/liferay/* /home/liferay
 
-ENTRYPOINT /usr/local/bin/liferay_entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/liferay_entrypoint.sh"]
 
 ENV JPDA_ADDRESS=8000
 


### PR DESCRIPTION
…utdown is broken

Prevent the entrypoint from forking on bash SHEBANG and breaking the signal handling meant to be on PID 1
With suggestions from @thecosmicfrog

Signed-off-by: Raymond Augé <raymond.auge@liferay.com>