### PR TITLE
DOCKER-93

### DIFF
--- a/build_all_images.sh
+++ b/build_all_images.sh
@@ -137,7 +137,7 @@ function get_main_key {
 
 	for main_key in ${main_keys}
 	do
-		local count=$(echo "${version}" | grep -c "${main_key}")
+		local count=$(echo "${version}" | grep -c -E "${main_key}-|${main_key}\.")
 
 		if [ "${count}" -gt 0 ]
 		then


### PR DESCRIPTION
DOCKER-93 Bugfix: version mismatch during yaml crawl.

The queries are attached to the ticket in a file. Now every major key matches the minor key.