### PR TITLE
DOCKER-129 Improve the process of locally built image

### DIFF
--- a/_common.sh
+++ b/_common.sh
@@ -183,14 +183,17 @@ function prepare_tomcat {
 
 	configure_tomcat
 
-	warm_up_tomcat
+	if [[ ! " ${@} " =~ " no_warm_up " ]]
+	then
+		warm_up_tomcat
+	fi
 
 	rm -fr "${TEMP_DIR}"/liferay/logs/*
 	rm -fr "${TEMP_DIR}"/liferay/tomcat/logs/*
 }
 
 function remove_temp_dockerfile_platform_variable {
-	sed -i 's/--platform=${TARGETPLATFORM} //g' "${TEMP_DIR}"/Dockerfile
+	sed -i'.bak' 's/--platform=${TARGETPLATFORM} //g' "${TEMP_DIR}"/Dockerfile
 }
 
 function start_tomcat {
@@ -225,9 +228,13 @@ function start_tomcat {
 
 	"./${TEMP_DIR}/liferay/tomcat/bin/catalina.sh" stop
 
-	sleep 30
+	for i in {0..30..1}; do
+		if kill -0 "${pid}" 2>/dev/null; then
+			sleep 1
+		fi
+	done
 
-	kill -9 "${pid}" 2>/dev/null
+	kill -0 "${pid}" 2>/dev/null && kill -9 "${pid}" 2>/dev/null
 
 	rm -fr "${TEMP_DIR}/liferay/data/osgi/state"
 	rm -fr "${TEMP_DIR}/liferay/osgi/state"
@@ -245,13 +252,16 @@ function stat {
 function test_docker_image {
 	export LIFERAY_DOCKER_IMAGE_ID="${DOCKER_IMAGE_TAGS[0]}"
 
-	./test_image.sh
-
-	if [ $? -gt 0 ]
+	if [[ ! " ${@} " =~ " no_test_image " ]]
 	then
-		echo "Testing failed, exiting."
+		./test_image.sh
 
-		exit 2
+		if [ $? -gt 0 ]
+		then
+			echo "Testing failed, exiting."
+
+			exit 2
+		fi
 	fi
 }
 

--- a/build_local_image.sh
+++ b/build_local_image.sh
@@ -26,14 +26,14 @@ function build_docker_image {
 function check_usage {
 	if [ ! -n "${3}" ]
 	then
-		echo "Usage: ${0} path-to-bundle image-name version <push>"
+		echo "Usage: ${0} path-to-bundle image-name version <push> [no_warm_up] [no_test_image]"
 		echo ""
 		echo "Example: ${0} ../bundles/master portal-snapshot demo-cbe09fb0 <push>"
 
 		exit 1
 	fi
 
-	check_utils curl docker java
+	check_utils curl docker java rsync
 }
 
 function main {
@@ -43,21 +43,23 @@ function main {
 
 	prepare_temp_directory "${@}"
 
-	prepare_tomcat
+	prepare_tomcat "${@}"
 
 	build_docker_image "${@}"
 
-	test_docker_image
-
-	log_in_to_docker_hub
-
-	push_docker_images "${4}"
+	test_docker_image "${@}"
 
 	clean_up_temp_directory
 }
 
 function prepare_temp_directory {
-	cp -a "${1}" "${TEMP_DIR}/liferay"
+	rsync -aq "${1}" "${TEMP_DIR}/liferay" \
+		--exclude '*.zip' \
+		--exclude 'data/elasticsearch*' \
+		--exclude 'logs/*' \
+		--exclude 'osgi/state' \
+		--exclude 'osgi/test' \
+		--exclude 'tmp'
 }
 
 main "${@}"

--- a/templates/bundle/Dockerfile
+++ b/templates/bundle/Dockerfile
@@ -1,4 +1,11 @@
-FROM --platform=${TARGETPLATFORM} liferay/jdk11:latest
+FROM --platform=${TARGETPLATFORM} liferay/jdk11:latest AS osbase
+
+RUN apt-get update && \
+	apt-get install -y ffmpeg fonts-dejavu ghostscript imagemagick gifsicle libtcnative-1 && \
+	apt-get upgrade -y && \
+	apt-get clean
+
+FROM osbase
 
 ARG LABEL_BUILD_DATE
 ARG LABEL_LIFERAY_VCS_REF
@@ -8,11 +15,6 @@ ARG LABEL_VCS_REF
 ARG LABEL_VCS_URL
 ARG LABEL_VERSION
 ARG TARGETPLATFORM
-
-RUN apt-get update && \
-	apt-get install -y ffmpeg fonts-dejavu ghostscript imagemagick gifsicle libtcnative-1 && \
-	apt-get upgrade -y && \
-	apt-get clean
 
 COPY scripts/* /usr/local/bin/
 
@@ -46,8 +48,8 @@ ENV LIFERAY_USERS_PERIOD_REMINDER_PERIOD_QUERIES_PERIOD_ENABLED=false
 EXPOSE 8000 8009 8080 11311
 
 HEALTHCHECK \
-	--interval=1m \
-	--start-period=1m \
+	--interval=4s \
+	--start-period=10s \
 	--timeout=1m \
 	CMD curl -fsS "http://localhost:8080/c/portal/layout" || exit 1
 

--- a/test_image.sh
+++ b/test_image.sh
@@ -83,11 +83,9 @@ function prepare_mount {
 
 	if [ -n "${LIFERAY_DOCKER_TEST_PATCHING_TOOL_URL}" ]
 	then
-		local patcing_tool_file_name=${LIFERAY_DOCKER_TEST_PATCHING_TOOL_URL##*/}
+		local patching_tool_file_name=${LIFERAY_DOCKER_TEST_PATCHING_TOOL_URL##*/}
 
-		download "downloads/patching-tool/${patcing_tool_file_name}" "${LIFERAY_DOCKER_TEST_PATCHING_TOOL_URL}"
-	else
-		local patcing_tool_file_name=$(find downloads/patching-tool/ -maxdepth 1 -name '*.zip' -printf "%T+\t%f\n" | sort | tail -n 1 | awk '{print $2}')
+		download "downloads/patching-tool/${patching_tool_file_name}" "${LIFERAY_DOCKER_TEST_PATCHING_TOOL_URL}"
 	fi
 
 	if [ -n "${LIFERAY_DOCKER_TEST_HOTFIX_URL}" ]


### PR DESCRIPTION
For example:

]$ ./build_local_image.sh ~/bundles/ dxp snapshot no_warm_up no_test_image

Builds the image in less than 30 seconds when upstream dependencies are cached