### PR TITLE
DOCKER-131 Do not install recommended packages

### DIFF
--- a/templates/base/Dockerfile
+++ b/templates/base/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=${TARGETPLATFORM} ubuntu:jammy AS ubuntu-jammy
 
 RUN apt-get update && \
-	apt-get install -y bash curl less libnss3 telnet tini tree unzip && \
+	apt-get install --no-install-recommends -y bash curl less libnss3 telnet tini tree unzip && \
 	apt-get upgrade -y && \
 	apt-get clean
 

--- a/templates/bundle/Dockerfile
+++ b/templates/bundle/Dockerfile
@@ -1,7 +1,7 @@
 FROM --platform=${TARGETPLATFORM} liferay/jdk11:latest AS liferay-jdk11
 
 RUN apt-get update && \
-	apt-get install -y ffmpeg fonts-dejavu ghostscript imagemagick gifsicle libtcnative-1 && \
+	apt-get install --no-install-recommends -y ffmpeg fonts-dejavu ghostscript imagemagick gifsicle libtcnative-1 && \
 	apt-get upgrade -y && \
 	apt-get clean
 

--- a/templates/jdk11-jdk8/Dockerfile
+++ b/templates/jdk11-jdk8/Dockerfile
@@ -24,7 +24,7 @@ ARG TARGETPLATFORM
 ENV JAVA_VERSION=zulu8
 
 RUN curl -H 'accept: */*' -L -s -X 'GET' -o /tmp/jdk8.deb "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/binary/?arch=${TARGETARCH}&bundle_type=jdk&ext=deb&hw_bitness=64&java_version=8.0&javafx=false&os=linux&zulu_version=${LABEL_ZULU_8_VERSION}" && \
-	apt-get install -y /tmp/jdk8.deb && \
+	apt-get install --no-install-recommends -y /tmp/jdk8.deb && \
 	rm /tmp/jdk8.deb && \
 	/usr/local/bin/set_java_version.sh
 

--- a/templates/jdk11/Dockerfile
+++ b/templates/jdk11/Dockerfile
@@ -23,14 +23,14 @@ ARG TARGETPLATFORM
 ENV JAVA_VERSION=zulu11
 
 COPY --chown=liferay:liferay home/.bashrc /home/liferay/
-COPY --chown=liferay:liferay scripts/set_java_version.sh /usr/local/bin/ 
+COPY --chown=liferay:liferay scripts/set_java_version.sh /usr/local/bin/
 
 RUN apt-get update && \
-	apt-get install -y jattach && \
+	apt-get install --no-install-recommends -y jattach && \
 	apt-get upgrade -y && \
 	apt-get clean && \
 	curl -H 'accept: */*' -L -s -X 'GET' -o /tmp/jdk11.deb "https://api.azul.com/zulu/download/community/v1.0/bundles/latest/binary/?arch=${TARGETARCH}&bundle_type=jdk&ext=deb&hw_bitness=64&java_version=11.0&javafx=false&os=linux&zulu_version=${LABEL_ZULU_11_VERSION}" && \
-	apt-get install -y /tmp/jdk11.deb && \
+	apt-get install --no-install-recommends -y /tmp/jdk11.deb && \
 	rm /tmp/jdk11.deb && \
 	/usr/local/bin/set_java_version.sh
 

--- a/templates/job-runner/Dockerfile
+++ b/templates/job-runner/Dockerfile
@@ -1,6 +1,6 @@
 FROM --platform=${TARGETPLATFORM} liferay/jdk11:latest AS liferay-jdk11
 
-RUN apt-get install cron && \
+RUN apt-get install --no-install-recommends cron && \
 	apt-get clean
 
 FROM liferay-jdk11


### PR DESCRIPTION
Using the option apt --no-install-recommends would save us 50-100 MiB of space in every container image. We should definitely use this switch in order to slim down our images and make our build process a bit faster.