### PR TITLE
DOCKER-137 Workaround as the patching does not work on dxp-18 with ap…

### DIFF
--- a/build_bundle_image.sh
+++ b/build_bundle_image.sh
@@ -182,10 +182,9 @@ function install_fix_pack {
 		cp "downloads/fix-packs/${FIX_PACK_FILE_NAME}" "${TEMP_DIR}/liferay/patching-tool/patches"
 
 		"${TEMP_DIR}/liferay/patching-tool/patching-tool.sh" install
-		"${TEMP_DIR}/liferay/patching-tool/patching-tool.sh" separate temp
 
+		rm -fr "${TEMP_DIR}/liferay/data/hypersonic/"*
 		rm -fr "${TEMP_DIR}/liferay/osgi/state/"*
-		rm -f "${TEMP_DIR}/liferay/patching-tool/patches/"*
 	fi
 }
 


### PR DESCRIPTION
…ply. The hypersonic update from ga1 to dxp-18 also fails in this context (rigthfully) and we need the fix pack to be available to install a hotfix. Size and startup time would increase, but this is needed until we fix the bundle patching to work with apply again.