### PR TITLE
SRE-2142 ARM64 support for zabbix agent

### DIFF
--- a/orca/templates/liferay/Dockerfile
+++ b/orca/templates/liferay/Dockerfile
@@ -2,7 +2,8 @@ FROM liferay/dxp:7.4.13-u45-d5.0.1-20221006125539
 
 USER 0
 
-RUN curl -H 'accept: */*' -L -s -X 'GET' -o /tmp/zabbix_agent.deb https://repo.zabbix.com/zabbix/6.3/ubuntu/pool/main/z/zabbix-release/zabbix-release_6.3-1%2Bubuntu22.04_all.deb && \
+RUN if test $(dpkg --print-architecture) = "arm64"; then zabbix_platform="ubuntu-arm64"; else zabbix_platform="ubuntu"; fi && \
+	curl -H 'accept: */*' -L -s -X 'GET' -o /tmp/zabbix_agent.deb https://repo.zabbix.com/zabbix/6.3/${zabbix_platform}/pool/main/z/zabbix-release/zabbix-release_6.3-1%2Bubuntu22.04_all.deb && \
 	dpkg -i /tmp/zabbix_agent.deb && \
 	rm -fr /tmp/zabbix_agent.deb && \
 	apt-get update && \


### PR DESCRIPTION
The reason for the unconventional if statement is that by default Docker uses Bourne Shell (/bin/sh) instead of GNU Bourne-Again Shell (/bin/bash), because of this the usual format does not work, as it's not supported by sh.