### PR TITLE
DOCKER-164 Implement day based caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 package-lock.json
 package.json
 temp-*
+templates/_common/etc/creation-date

--- a/_common.sh
+++ b/_common.sh
@@ -165,6 +165,18 @@ function log_in_to_docker_hub {
 	fi
 }
 
+function make_creation_date_file {
+	local current_date=$(date)
+	current_date=$(date "${current_date}" "+%D")
+
+	local file_date=$(cat templates/_common/etc/creation-date)
+
+	if [[ "${current_date}" != "${file_date}" ]]
+	then
+		echo "${current_date}" > templates/_common/etc/creation-date
+	fi
+}
+
 function make_temp_directory {
 	CURRENT_DATE=$(date)
 
@@ -174,6 +186,9 @@ function make_temp_directory {
 
 	mkdir -p "${TEMP_DIR}"
 
+	make_creation_date_file
+
+	cp -r templates/_common/* "${TEMP_DIR}"
 	cp -r "${1}"/* "${TEMP_DIR}"
 }
 

--- a/orca/scripts/build_services.sh
+++ b/orca/scripts/build_services.sh
@@ -345,8 +345,8 @@ function build_services {
 		rm -fr docker-build
 		mkdir -p docker-build
 
-		cp -a templates/_common/* docker-build
-		cp -a templates/${SERVICE_NAME}/* docker-build
+		cp -r templates/_common/* docker-build
+		cp -r templates/${SERVICE_NAME}/* docker-build
 
 		build_service_$(echo ${SERVICE_NAME} | sed -e "s/-/_/g")
 

--- a/spinner/build.sh
+++ b/spinner/build.sh
@@ -80,8 +80,8 @@ function create_liferay_configuration {
 
 	mkdir -p liferay_mount/files
 
-	cp -a ${LIFERAY_LXC_REPOSITORY_DIR}/liferay/configs/common/* liferay_mount/files
-	cp -a ${LIFERAY_LXC_REPOSITORY_DIR}/liferay/configs/${ENVIRONMENT}/* liferay_mount/files
+	cp -r ${LIFERAY_LXC_REPOSITORY_DIR}/liferay/configs/common/* liferay_mount/files
+	cp -r ${LIFERAY_LXC_REPOSITORY_DIR}/liferay/configs/${ENVIRONMENT}/* liferay_mount/files
 
 	echo "Deleting the following files from configuration to ensure DXP can run locally:"
 

--- a/templates/base/Dockerfile
+++ b/templates/base/Dockerfile
@@ -1,5 +1,7 @@
 FROM --platform=${TARGETPLATFORM} ubuntu:jammy AS ubuntu-jammy
 
+COPY --chown=liferay:liferay etc/creation-date /etc/creation-date
+
 RUN apt-get update && \
 	DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install --no-install-recommends --yes bash ca-certificates curl less libnss3 telnet tini tree unzip && \
 	apt-get upgrade --yes && \

--- a/templates/bundle/Dockerfile
+++ b/templates/bundle/Dockerfile
@@ -1,5 +1,7 @@
 FROM --platform=${TARGETPLATFORM} liferay/jdk11:latest AS liferay-jdk11
 
+COPY --chown=liferay:liferay etc/creation-date /etc/creation-date
+
 RUN apt-get update && \
 	DEBIAN_FRONTEND=noninteractive TZ=Etc/UTC apt-get install --no-install-recommends --yes ffmpeg fonts-dejavu ghostscript google-perftools imagemagick gifsicle libtcnative-1 && \
 	apt-get upgrade --yes && \

--- a/templates/caddy/Dockerfile
+++ b/templates/caddy/Dockerfile
@@ -6,6 +6,7 @@ ARG LABEL_VCS_REF
 ARG LABEL_VCS_URL
 ARG LABEL_VERSION
 
+COPY --chown=liferay:liferay etc/creation-date /etc/creation-date
 COPY resources/etc/caddy/* /etc/caddy
 COPY resources/usr/local/bin/* /usr/local/bin/
 

--- a/templates/dynamic-rendering/Dockerfile
+++ b/templates/dynamic-rendering/Dockerfile
@@ -9,6 +9,7 @@ ARG LABEL_VERSION
 ARG TARGETARCH
 ARG TARGETPLATFORM
 
+COPY --chown=liferay:liferay etc/creation-date /etc/creation-date
 COPY resources/usr/src/app/* /usr/src/app
 
 ENV MEMORY_CACHE=0

--- a/templates/jdk11-jdk8/Dockerfile
+++ b/templates/jdk11-jdk8/Dockerfile
@@ -21,6 +21,8 @@ ARG LABEL_ZULU_8_VERSION
 ARG TARGETARCH
 ARG TARGETPLATFORM
 
+COPY --chown=liferay:liferay etc/creation-date /etc/creation-date
+
 ENV JAVA_VERSION=zulu8
 
 LABEL org.label-schema.build-date="${LABEL_BUILD_DATE}"

--- a/templates/jdk11/Dockerfile
+++ b/templates/jdk11/Dockerfile
@@ -20,6 +20,7 @@ ARG LABEL_VERSION
 ARG TARGETARCH
 ARG TARGETPLATFORM
 
+COPY --chown=liferay:liferay etc/creation-date /etc/creation-date
 COPY --chown=liferay:liferay resources/home/liferay/.bashrc /home/liferay/
 COPY resources/usr/local/bin/* /usr/local/bin/
 

--- a/templates/job-runner/Dockerfile
+++ b/templates/job-runner/Dockerfile
@@ -13,6 +13,7 @@ ARG LABEL_VCS_URL
 ARG LABEL_VERSION
 ARG TARGETPLATFORM
 
+COPY --chown=liferay:liferay etc/creation-date /etc/creation-date
 COPY resources/usr/local/bin/* /usr/local/bin/
 
 ENTRYPOINT ["tini", "-v", "--", "/usr/local/bin/liferay_job_runner_entrypoint.sh"]

--- a/templates/zabbix-server/Dockerfile
+++ b/templates/zabbix-server/Dockerfile
@@ -17,6 +17,7 @@ ARG LABEL_ZABBIX_VERSION
 
 CMD ["/usr/sbin/zabbix_server", "--foreground", "-c", "/etc/zabbix/zabbix_server.conf"]
 
+COPY --chown=liferay:liferay etc/creation-date /etc/creation-date
 COPY --from=zabbix-server-mysql ["/etc/zabbix", "/etc/zabbix"]
 COPY --from=zabbix-server-mysql ["/usr/bin/docker-entrypoint.sh", "/usr/bin/docker-entrypoint.sh"]
 COPY --from=zabbix-server-mysql ["/usr/bin/zabbix_get", "/usr/bin/zabbix_get"]

--- a/templates/zabbix-web/Dockerfile
+++ b/templates/zabbix-web/Dockerfile
@@ -15,6 +15,7 @@ ARG LABEL_VCS_URL
 ARG LABEL_VERSION
 ARG LABEL_ZABBIX_VERSION
 
+COPY --chown=liferay:liferay etc/creation-date /etc/creation-date
 COPY --from=zabbix-web-nginx-mysql ["/etc/apt/preferences.d/99nginx", "/etc/apt/preferences.d/99nginx"]
 COPY --from=zabbix-web-nginx-mysql ["/etc/apt/sources.list.d/nginx.list", "/etc/apt/sources.list.d/nginx.list"]
 COPY --from=zabbix-web-nginx-mysql ["/etc/apt/trusted.gpg.d/nginx.gpg", "/etc/apt/trusted.gpg.d/nginx.gpg"]


### PR DESCRIPTION
This will invalidate the `COPY --chown=liferay:liferay etc/creation-date /etc/creation-date` layer every day. Based on the official docker documentation: https://docs.docker.com/build/cache/

> If a layer changes, all other layers that come after it are also affected. When the layer with the COPY command gets invalidated, all layers that follow will need to run again, too:

This means that every day the package installation will run again, this will ensure that our images arrive with the latest packages, which will eliminate a lot of manual work.

The reason for the .gitkeep file is to have the directory structure in the git repository as git is unable to commit empty directories and the date file is in the .gitignore.