### PR TITLE
LPS-194203 Use LIFERAY_ROUTES env

### DIFF
--- a/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
+++ b/templates/batch/resources/usr/local/bin/liferay_batch_entrypoint.sh
@@ -8,14 +8,30 @@ function main {
 		exit 1
 	fi
 
+	if [ ! -n "${LIFERAY_ROUTES_CLIENT_EXTENSION}" ]
+	then
+		local LIFERAY_ROUTES_CLIENT_EXTENSION="/etc/liferay/lxc/ext-init-metadata"
+	fi
+
+	if [ ! -n "${LIFERAY_ROUTES_DXP}" ]
+	then
+		local LIFERAY_ROUTES_DXP="/etc/liferay/lxc/dxp-metadata"
+	fi
+
 	echo "OAuth Application ERC: ${LIFERAY_BATCH_OAUTH_APP_ERC}"
 	echo ""
 
-	local lxc_dxp_main_domain=$(cat /etc/liferay/lxc/dxp-metadata/com.liferay.lxc.dxp.mainDomain)
-	local lxc_dxp_server_protocol=$(cat /etc/liferay/lxc/dxp-metadata/com.liferay.lxc.dxp.server.protocol)
-	local oauth2_client_id=$(cat /etc/liferay/lxc/ext-init-metadata/${LIFERAY_BATCH_OAUTH_APP_ERC}.oauth2.headless.server.client.id)
-	local oauth2_client_secret=$(cat /etc/liferay/lxc/ext-init-metadata/${LIFERAY_BATCH_OAUTH_APP_ERC}.oauth2.headless.server.client.secret)
-	local oauth2_token_uri=$(cat /etc/liferay/lxc/ext-init-metadata/${LIFERAY_BATCH_OAUTH_APP_ERC}.oauth2.token.uri)
+	local lxc_dxp_main_domain=$(cat ${LIFERAY_ROUTES_DXP}/com.liferay.lxc.dxp.main.domain)
+
+	if [ ! -n "${lxc_dxp_main_domain}" ]
+	then
+		lxc_dxp_main_domain=$(cat ${LIFERAY_ROUTES_DXP}/com.liferay.lxc.dxp.mainDomain)
+	fi
+
+	local lxc_dxp_server_protocol=$(cat ${LIFERAY_ROUTES_DXP}/com.liferay.lxc.dxp.server.protocol)
+	local oauth2_client_id=$(cat ${LIFERAY_ROUTES_CLIENT_EXTENSION}/${LIFERAY_BATCH_OAUTH_APP_ERC}.oauth2.headless.server.client.id)
+	local oauth2_client_secret=$(cat ${LIFERAY_ROUTES_CLIENT_EXTENSION}/${LIFERAY_BATCH_OAUTH_APP_ERC}.oauth2.headless.server.client.secret)
+	local oauth2_token_uri=$(cat ${LIFERAY_ROUTES_CLIENT_EXTENSION}/${LIFERAY_BATCH_OAUTH_APP_ERC}.oauth2.token.uri)
 
 	echo "LXC DXP Main Domain: ${lxc_dxp_main_domain}"
 	echo "LXC DXP Server Protocol: ${lxc_dxp_server_protocol}"

--- a/templates/caddy/resources/usr/local/bin/liferay_caddy_entrypoint.sh
+++ b/templates/caddy/resources/usr/local/bin/liferay_caddy_entrypoint.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
 
 function main {
-	for i in $(cat /etc/liferay/lxc/dxp-metadata/com.liferay.lxc.dxp.domains 2>/dev/null)
+	if [ ! -n "${LIFERAY_ROUTES_DXP}" ]
+	then
+		local LIFERAY_ROUTES_DXP="/etc/liferay/lxc/dxp-metadata"
+	fi
+
+	for i in $(cat ${LIFERAY_ROUTES_DXP}/com.liferay.lxc.dxp.domains 2>/dev/null)
 	do
 		local url="https://${i}"
 


### PR DESCRIPTION
- U76
- SRE-3504 DXP 7.3 U25: Docker Image
- SRE-3511 Start jenkins docker automatically
- SRE-3511 Grant access to akos.kreutz on bob1
- SRE-3046 Fix pts_hosts's add.pp
- SRE-3511 Fix node definition
- SRE-3511 Fix pts_hosts
- SRE-3458 Enable reading various configuration options
- SRE-3458 Automate importing the database
- SRE-3458 Allowing to choose stack name
- SRE-3458 Fixing minor issues, allowing randomizing mysql external port
- SRE-3458 Allowing skipping table imports
- SRE-3511 Fix jenkins install
- SRE-3086 Fix bob1's ip
- LRP-4511 Reorg json so it's easier to debug later + enable using local release
- LRP-4511 Skip if the update is already available unzipped
- LRP-4511 Should not fail if there were no added files
- LRP-4511 Change to hotfix.json
- LRP-4511 Patch information is the most important, let's move it up
- LRP-4511 Fixing release build + properly comparing the dirs
- LRP-4511 Adding some documentation
- LRP-4511 git pull was missing and the branch did not get updated
- LRP-4511 Moving the documentation of env variables to the Dockerfile so things won't be out of sync
- LRP-4511 Adding test hotfixing code
- LRP-4499 Switching to SHA256 + fix find order
- LRP-4511 Change to singular
- LRP-4530 We need to run setup-profile-dxp every time there's a SHA change
- LRP-4496 Rename update to release to enable the quarterly releases to be supported
- LRP-4496 Rename tomcat before we can implement LPS-182849
- U77
- LRP-4528 Installing google cloud tools
- LRP-4528 Automatically init gcs
- LRP-4528 Make sure we wait at the right time
- LRP-4528 Uploading releases works now
- LRP-4528 Upload for hotfixes
- LRP-4528 Fix path
- LRP-4499 Shouldn't calculate checksums for dirs
- LRP-4468 Reorg to smaller units
- LRP-4468 Make git checkout and error management more roboust
- LRP-4527 Decrementing the module versions to match what's included in the release
- DOCKER-205 commands not found for jar runner
- 5.0.35 change log
- U78
- SRE-3594 7.3 U26 Docker Image
- DOCKER-204 Update Patching Tool to 3.0.38
- 5.0.36 change log
- SRE-3511 Add jenkins' ssh key
- SRE-3511 Add ci profile to jenkins nodes
- SRE-3511 Add 'ubuntu' user
- LRP-4541 Adding colors to see status easier
- LRP-4541 Add warmup step
- LRP-4541 Remove licensing code for now so tomcat can successfully start up
- LRP-4540 If the test_release is not available, just the folder, we should fail the process
- LRP-4540 Fix typos
- LRP-4540 Introduce the OSGI_BASE_PATH
- LRP-4540 Smarter excluding
- LRP-4540 Fix file name for hotfixes
- U79
- LRP-4540 Cleanup
- LRP-4545 Simplify cleaning for devs
- LRP-4545 Fixing warmup skipping + proper hotfix naming
- LRP-4545 We need to clean up properly if we constantly switch between branches
- LRP-4545 X is not necessary, rebuild if hotfix testing code was added
- LRP-4547 Adding back the licensing logic
- LRP-4547 Needed to add a few more compile rounds to make licensing work
- LRP-4550 Workaround for LPS-186850
- LRP-4548 Deploying ES Sidecar
- SRE-3482 Establishing the pattern for _liferay_common.sh
- SRE-3482 Another useful example
- SRE-3482 Wordsmith
- SRE-3482 SF
- LRP-4545 Proper closing message
- LRP-4542 Deploy the osgi modules
- SRE-3482 Fix typo + SF
- SRE-3482 Proper error message for lc_cd
- SRE-3482 print all utils which are not installed, not just the first one
- SRE-3482 Switch to UTC and set it universally
- SRE-3277 Add the time run method to common
- SRE-3277 SF
- SRE-3277 SF
- SRE-3720 Adding _liferay_common.sh
- SRE-3720 Switch to _liferay_common.sh
- SRE-3720 Refactoring out the liferay_service
- SRE-3720 Switching back to write
- SRE-3720 Moving search out
- SRE-3720 Moving out webserver
- SRE-3720 Renaming, cleaning up
- U80
- 7.3 U27
- Bad space
- Rename
- Rename
- Wordsmith
- Sort
- Please fix if I don't know Bash
- Wordsmith
- Rename
- Rename
- SF
- SF
- SF
- SF
- SRE-3720 Use the root _liferay_common as it depends orca so shallow clone is not an option for spinner
- SRE-3720 Add docker compose
- SRE-3720 Move clean to time_run to demonstrate how to use it
- Reuse lc_docker_compose
- SRE-3720 Rename
- SRE-3720 Fix docs
- Sort
- Should be the same
- Rename to match Orca
- Rename to match Orca
- Rename
- Wrong link
- Wordsmith
- Wordsmith
- Spell it out
- Wordsmith
- Fix dir, SF
- SF/Wordsmith
- SF/Wordsmith
- SF/Wordsmith
- SF/Wordsmith
- SF/Wordsmith
- SF/Wordsmith
- LRP-4542 Move to build-app-jar-release
- Method to read properties from properties and bnd files
- Rename
- Fix check for the right value
- SF
- Remove the correct files
- Replace the webserver configuration to be taken from the image directly
- haproxy.cfg needs to be changed
- Use sed instead of grep
- Use double quotes as it's safe
- Only use liferay-1 now as if liferay-2 is not started, haproxy won't be happy
- Missing /
- Beautiful...
- Replace _liferay_common with the real one
- Replace SKIPPED and time_run
- Replacing exit codes to constants
- SF and cleanup
- Change directories
- Move to lc_cd
- Fix wrong method name
- Fix method
- Separate compile from obfuscate
- U81
- Use proper 7z suffix
- SRE-3735 Move the configs to the right place so the web-server image would correctly pick it up (and not use the legacy scripts)
- SRE-3735 If we don't make changes to these files, we don't even need to copy them
- SRE-3735 Fix path
- SRE-3735 SF
- SRE-3277 Add scripts to share source code
- SRE-3277 Add _liferay_common.sh to code sharing
- SRE-3277 Use _liferay_common.sh
- SRE-3277 Generalize the code
- SRE-3277 Use functions
- SRE-3277 Add git init to the main script
- SRE-3277 Remove unused Jenkinsfile
- SRE-3277 Remove liferay-dxp_init.sh
- SRE-3277 Add parameter checks to functions
- SRE-3277 Update _liferay_common.sh to fix the SKIPPED issue
- SRE-3277 Simplify by reordering how we push
- SRE-3277 Rename
- Skip other building steps if the bundle was already built
- The rename was not done properly.
- Adding gitignore to avoid generated files
- Rename the script
- Rename dir
- Clamav needs more than 1G
- 7.4 hotfix test
- Take the antivirus from the config. Not using jq as it would not be installed by default in WSL
- SF
- SRE-3786 Remove the created nginx container
- SRE-3786 SF
- Supporting mod_security
- Copy files for mod_sec from the official owasp container
- Load the rules
- Not needed
- Disable access log as it's not useful
- Remove the container once it's not needed
- SF
- Add a quick test case to validate the setup
- Wrong dir
- SRE-3046 Re-add sorted teleport.yaml
- Add patcher.properties to hotfix
- The base image doesn't have different locales
- We should keep the UTF-8
- U82
- SRE-3042 Add node: ig11.dso.lfr
- SRE-3042 Add node: puppet.dso.lfr
- SRE-3042 Add 'host' package
- SRE-3042 Change puppet server's address
- SRE-3042 Tuning root's environment
- SRE-3042 Add node: jay
- SRE-3042 Fix syntax
- SRE-3042 Add docker to jay
- SRE-3042 Fix PS1 colors
- SRE-3042 Tune ls command switches
- SRE-3042 Rename jay to narwhalci
- SRE-3042 Add docker-compose.yaml to narwhalci
- SRE-3042 Remove spaces
- U82 with fix
- DOCKER-210 Thread dump generation in case of build failure
- DOCKER-210 Moving thread dumps from test to log dir
- DOCKER-210 Rename
- DOCKER-210 Sort
- DOCKER-210 Rename
- DOCKER-210 Sort
- DOCKER-210 SF
- DOCKER-210 SF
- DOCKER-210 Wordsmith
- 5.0.37 change log
- DOCKER-210 Fixing curl issue
- 5.0.38 change log
- DOCKER-210 Moving to docker cp due to issues with rootless docker
- We should generate thread dump on all errors + we don't need to create the variable
- Improve Randomize option to allow multiple servers with different versions
- Add new -n option to increase the number of possible clusters
- Add new option to access spinner from local network
- Renaming variables
- Simplify logic
- {1..${a}} does not work here
- Sort
- Wordsmith
- Wordsmith
- Why would we ever not want to listen on all interfaces?
- This is not true. We are not creating 'clusters'. We are setting the number of nodes in 1 cluster.
- Avoid periods when it's just 1 phrase
- 5.0.39 change log
- U83
- u83 typo
- SRE-3857 Liferay DXP 7.3 U28 Docker Image
- LRP-4576 Minor changes to the documentation format to make it proper json
- Revert "Why would we ever not want to listen on all interfaces?"
- This is safe because Docker protects it
- Wordsmith
- Rename
- SRE-3903 Liferay 7.3 DXP U29 Docker Image
- SRE-3010 Output Thread dump under 1 log line on probe failures
- Add host.docker.internal:host-gateway to allow run spinner with Client Extensions
- SRE-3903 Ignore hotfix test right now as the hello world portlet changed, changes the releases-cdn to be able to test properly
- U84
- U85
- Fix database import from relative path + shellcheck SF
- Update password in all databases + remove SSO config
- Sort
- SF
- U86
- U86
- U87
- U88
- U89
- 7.3 U30
- U90
- SRE-4411 Docker Image 7.3 U31
- U91
- DOCKER-215 Adding CIDFallBack font for GhostScript
- 5.0.40 change log
- U92
- 7.3 U32
- u93
- SRE-3042 Add tang server
- LRP-4614 Add script to speed up development
- LRP-4614 Move the .war files to osgi instead of deploy + remove the test jars
- LRP-4556 Adding the license folder
- LRP-4614 Speed up development by skipping already completed steps
- LRP-4614 Skip legal
- LRP-4614 Automatically delete the unnecessary modules
- LRP-4614 Fix while loops
- LRP-4614 deploy-portal-license-enterprise-app
- LRP-4614 We need package bundle back
- LRP-4614 We also need to delete from portal, not just modules
- LRP-4614 Warmup is needed for faster startup
- LRP-4614 Add tools to generate the signature
- LRP-4614 Clean osgi/state temporarily
- LRP-4614 SF on the SignatureUtil
- LRP-4614 Move the release builder to enable it running locally
- LRP-4614 Let's rename the entrypoint
- LRP-4614 Move env variable defaults from Docker
- LRP-4614 Replace paths
- LRP-4614 Include from local
- LRP-4614 Fix paths, Docker jvm configuration is not needed
- LRP-4614 Rename NARWHAL to LIFERAY_RELEASE
- LRP-4614 Clean up git usage
- LRP-4614 Add check_usage
- LRP-4614 Use timestamp instead of SHA for now
- LRP-4614 Moving from Docker this should not be necessary
- LRP-4614 SF
- Update to latest _liferay_common.sh
- Use new pattern to prefix private vars like this
- .liferay is for Gradle workspace and some Ant scripts. .liferay-device is for Fedora. So let's use .liferay-release
- SF
- SF
- SF
- SF
- Wordsmith/SF
- Rename
- SF
- SF
- SF
- SF
- SF
- SF
- Rename
- SF
- SF
- SF
- SF
- SF
- SF
- SF
- SF
- U94
- DOCKER-220 Adding a test image
- 5.0.41 change log
- LRP-4614 Detect Q versions, update the release date automatically
- LRP-4614 Return BAD when something is not correct
- LRP-4614 .tar.gz + md5 checksums, use 2023.q3 as an example
- LRP-4614 Fix branch name
- LRP-4614 Fix tar paths
- LRP-4614 Add zip
- LRP-4614 Fix upload skip
- LRP-4614 Upload files one-by-one
- LRP-4614 Add the sql zip
- LRP-4614 List the uploaded files
- LRP-4614 osgi
- LRP-4614 Zipping up the war file
- LRP-4614 Build the tools file
- LRP-4614 Enable setting the file name of the secret
- LRP-4614 Inline replace the date
- LRP-4614 Fix typo
- LRP-4614 Fix step counting issues
- LRP-4614 Give time for tomcat to write the files, the site initializer not always finished e.g. adding the logo to the doc lib
- RELEASE-5396 Add sha512 sums to the build as md5 does not satisfy our customers anymore. We will need to keep md5 until we can add sha512 parsing to the Customer Portal
- SF
- Document
- Document
- Document
- SRE-4642 Docker Image 7.3 U33
- LRQA-83053 Fix typo
- Add patching-tool to the release (will need to replace with 4.0 once it's ready)
- We need to update the release date before setting up the DXP profile
- Adding hotfix signature
- Sort
- Release dir fixes
- Fix 7z path
- Only fetch the tag when SHA is not available
- Support different timestamps
- If only these files changed in a jar, we don't need to package them
- Do not run parallel as some jars might finish too late
- Skip directories
- Use the timestamp if hotfix_id is not specified
- Enable it to run on jenkins
- Double
- This needs to go first because it's referenced by LIFERAY_RELEASE_HOTFIX_ID
- Wordsmith
- Switch to 4.0 PT
- Temporary change, LXC SM relies on the '7.4' in the image tag name. See https://liferay.atlassian.net/browse/LCD-31143
- Fix test hotfix id issue
- Fix merge difference
- Let's use the latest bundle
- U95
- Ran update_permissions
- Squid
- Use the direct URL as we need to quickly build new releases after the PT release
- LPR-4630 Add the ability to ignore cache
- LRP-4633 Use the file name which is actually read by DXP
- Update to latest build
- Rephrase to match "Copying.." 3 lines below
- Rename
- Comment it out for now
- Revert "Comment it out for now"
- Use 3129 instead, it's more Squid like
- Forgot ARG
- DOCKER-226 Remove no longer used Liferay Stack in favor of Spinner
- 5.0.42 change log
- Squid cache properly
- Order matters
- SRE-3042 Add user: Szantina Szanto
- SRE-3042 Fix jenkins version
- SRE-3042 gid and uid added
- Mark the tomcat file so tools can find it easily
- DOCKER-218 fixing node_runner build timeout 60 seconds
- DOCKER-218 Enable running of the individual scripts by setting the default value
- DOCKER-218 Clean in the end, use our regular install command, tee is not necessary (it's there if you would need to sudo)
- DOCKER-218 SF
- DOCKER-218 SF
- 5.0.43 change log
- SRE-3042 Rename bob5,6
- SRE-3042 Add pts_threatstack
- SRE-3042 Add pts_autoinstall
- SRE-3042 Add rsyslog
- SRE-3042 Add locales
- SRE-3042 Add package: dialog
- SRE-3042 Bumb jenkins version to 2.414.2
- update_release_tool depends on update_portal_repository information
- Sort
- DOCKER-224 Adjust locale settings
- DOCKER-224 We tested and it works with lowercase everywere
- LPS-194203 use LIFERAY_ROUTES_* env vars if available
