### PR TITLE
Set cert expiration to 365 days

### DIFF
--- a/templates/squid/resources/usr/local/bin/liferay_squid_entrypoint.sh
+++ b/templates/squid/resources/usr/local/bin/liferay_squid_entrypoint.sh
@@ -18,7 +18,7 @@ function main {
 			-keyout /etc/squid/seeder.key \
 			-new \
 			-newkey rsa:2048 \
-			-nodes -x509 \
+			-nodes -x509 -days 365 \
 			-out /etc/squid/seeder.crt \
 			-subj /C=US/ST=CA/L=LAX/O=Liferay/OU=IT/CN=localhost
 	fi


### PR DESCRIPTION
https://www.openssl.org/docs/manmaster/man1/openssl-req.html

> -days n
> When -x509 is in use this specifies the number of days to certify the certificate for, otherwise it is ignored. n should be a positive integer. The default is 30 days.