### PR TITLE
DOCKER-239

### DIFF
--- a/_common.sh
+++ b/_common.sh
@@ -233,8 +233,8 @@ function prepare_tomcat {
 }
 
 function remove_temp_dockerfile_target_platform {
-	sed -i'.bak' 's/${TARGETARCH}'/$(get_current_arch)/ "${TEMP_DIR}"/Dockerfile
-	sed -i'' 's/--platform=${TARGETPLATFORM} //g' "${TEMP_DIR}"/Dockerfile
+	sed -i='.bak' 's/${TARGETARCH}'/$(get_current_arch)/ "${TEMP_DIR}"/Dockerfile
+	sed -i='' 's/--platform=${TARGETPLATFORM} //g' "${TEMP_DIR}"/Dockerfile
 }
 
 function start_tomcat {

--- a/build_local_image.sh
+++ b/build_local_image.sh
@@ -26,9 +26,9 @@ function build_docker_image {
 function check_usage {
 	if [ ! -n "${3}" ]
 	then
-		echo "Usage: ${0} path-to-bundle image-name version --no-warm-up --no-test-image --push"
+		echo "Usage: ${0} path-to-bundle/ image-name version --no-warm-up --no-test-image --push"
 		echo ""
-		echo "Example: ${0} ../bundles/master portal-snapshot demo-cbe09fb0 --no-warm-up --no-test-image"
+		echo "Example: ${0} ../bundles/master/ portal-snapshot demo-cbe09fb0 --no-warm-up --no-test-image"
 
 		exit 1
 	fi

--- a/templates/bundle/resources/usr/local/bin/liferay_entrypoint.sh
+++ b/templates/bundle/resources/usr/local/bin/liferay_entrypoint.sh
@@ -8,7 +8,7 @@ function main {
 
 	if [[ "${DOCKER_TCMALLOC_ENABLED}" == "true" ]]
 	then
-		LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4"
+		LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libtcmalloc.so.4:${LD_PRELOAD}"
 
 		export LD_PRELOAD
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/DOCKER-239

Changes:
- Instead of clobbering LD_PRELOAD env when DOCKER_TCMALLOC_ENABLED optimization is enabled we prepend our LD_PRELOAD value.
- Fix `sed -i''` to `sed -i=''` for MAC (BSD sed) error -- I believe this is cross compatible and doesn't break GNU sed
- Fix `./build_local_image.sh` help instruction examples to have trailing `/` so that rysnc copies the directory contents without the directory as expected downstream by `get_tomcat_version`