### PR TITLE
LPD-30139 Dependencies Resources not being generated during a release building

### DIFF
--- a/release/_package.sh
+++ b/release/_package.sh
@@ -192,8 +192,7 @@ function package_release {
 		cp "${_PROJECTS_DIR}"/liferay-portal-ee/lib/development/hsql.jar "liferay-${LIFERAY_RELEASE_PRODUCT_NAME}-dependencies-${_PRODUCT_VERSION}"
 		cp "${_PROJECTS_DIR}"/liferay-portal-ee/lib/global/*.jar "liferay-${LIFERAY_RELEASE_PRODUCT_NAME}-dependencies-${_PRODUCT_VERSION}"
 		cp "${_PROJECTS_DIR}"/liferay-portal-ee/portal-kernel/portal-kernel.jar "liferay-${LIFERAY_RELEASE_PRODUCT_NAME}-dependencies-${_PRODUCT_VERSION}"
-
-		mv "${_PROJECTS_DIR}"/liferay-portal-ee/tools/sdk/dist/com.liferay.registry.api-*.jar "liferay-${LIFERAY_RELEASE_PRODUCT_NAME}-dependencies-${_PRODUCT_VERSION}/com.liferay.registry.api.jar"
+		cp "${_PROJECTS_DIR}"/liferay-portal-ee/tools/sdk/dist/com.liferay.registry.api-*.jar "liferay-${LIFERAY_RELEASE_PRODUCT_NAME}-dependencies-${_PRODUCT_VERSION}/com.liferay.registry.api.jar"
 
 		zip -qr "${_BUILD_DIR}/release/liferay-${LIFERAY_RELEASE_PRODUCT_NAME}-dependencies-${_PRODUCT_VERSION}-${_BUILD_TIMESTAMP}.zip" "liferay-${LIFERAY_RELEASE_PRODUCT_NAME}-dependencies-${_PRODUCT_VERSION}"
 


### PR DESCRIPTION
Related issue: https://liferay.atlassian.net/browse/LPD-30139
