### PR TITLE
SRE-6066

### DIFF
--- a/spinner/build.sh
+++ b/spinner/build.sh
@@ -52,9 +52,9 @@ function build_service_liferay {
 
 	if [ "$(git -C "${SPINNER_LIFERAY_LXC_REPOSITORY_DIR}" rev-parse --abbrev-ref HEAD)" == "master" ]
 	then
-		liferay_image=$(retrieve_descriptor_data "liferay-image")
+		liferay_image=$(get_environment_descriptor "liferay-image")
 
-		local hotfix=$(retrieve_descriptor_data "hotfix")
+		local hotfix=$(get_environment_descriptor "hotfix")
 
 		if [ ! -z "${hotfix}" ]
 		then
@@ -427,6 +427,19 @@ function check_usage {
 	mkdir -p "${STACK_DIR}"
 }
 
+function get_environment_descriptor {
+	local file="${SPINNER_LIFERAY_LXC_REPOSITORY_DIR}/automation/environment-descriptors/${LXC_ENVIRONMENT}.json"
+
+	if [ ! -f "${file}" ]
+	then
+		echo "It was not possible to find the environment-descriptor for ${LXC_ENVIRONMENT}."
+
+		exit "${LIFERAY_COMMON_EXIT_CODE_BAD}"
+	fi
+
+	echo "$(grep -e "\"${1}\":" "${file}" | cut -d'"' -f4)"
+}
+
 function main {
 	check_usage "${@}"
 
@@ -541,21 +554,6 @@ function print_help {
 	echo "Example: ${0} x1e4prd -d sql.gz -o test"
 
 	exit "${LIFERAY_COMMON_EXIT_CODE_HELP}"
-}
-
-function retrieve_descriptor_data {
-	local file="${SPINNER_LIFERAY_LXC_REPOSITORY_DIR}/automation/environment-descriptors/${LXC_ENVIRONMENT}.json"
-
-	if [ ! -f "${file}" ]
-	then
-		echo "It was not possible to find the environment-descriptor for ${LXC_ENVIRONMENT}."
-
-		exit "${LIFERAY_COMMON_EXIT_CODE_BAD}"
-	fi
-
-	value=$(grep -e "\"${1}\":" "${file}" | cut -d'"' -f4)
-
-	echo "${value}"
 }
 
 function write {

--- a/spinner/build.sh
+++ b/spinner/build.sh
@@ -48,26 +48,21 @@ function build_service_liferay {
 
 	cp ../../orca/templates/liferay/resources/usr/local/liferay/scripts/pre-startup/10_wait_for_dependencies.sh build/liferay/resources/usr/local/liferay/scripts/pre-startup
 
-	local branch=$(git -C "${SPINNER_LIFERAY_LXC_REPOSITORY_DIR}" rev-parse --abbrev-ref HEAD)
 	local liferay_image=""
 
-	if [ "${branch}" = "master" ]; then
-		echo "Currently checked out to the master branch."
-		echo ""
-
+	if [ "$(git -C "${SPINNER_LIFERAY_LXC_REPOSITORY_DIR}" rev-parse --abbrev-ref HEAD)" == "master" ]
+	then
 		liferay_image=$(retrieve_descriptor_data "liferay-image")
 
 		local hotfix=$(retrieve_descriptor_data "hotfix")
 
-		if [ ! -z "${hotfix}" ]; then
+		if [ ! -z "${hotfix}" ]
+		then
 			hotfix="RUN \/opt\/liferay\/patching-tool\/patching-tool.sh install ${hotfix}"
 		fi
 
 		sed -i "s/\[TO-BE-REPLACED-BY-SINGLE-CI\]/${hotfix}/g" "${SPINNER_LIFERAY_LXC_REPOSITORY_DIR}/liferay/Dockerfile.ext"
 	else
-		echo "Currently checked out to the ${branch} branch."
-		echo ""
-
 		liferay_image=$(grep -e '^liferay.workspace.docker.image.liferay=' "${SPINNER_LIFERAY_LXC_REPOSITORY_DIR}/liferay/gradle.properties" | cut -d'=' -f2)
 	fi
 
@@ -551,8 +546,8 @@ function print_help {
 function retrieve_descriptor_data {
 	local file="${SPINNER_LIFERAY_LXC_REPOSITORY_DIR}/automation/environment-descriptors/${LXC_ENVIRONMENT}.json"
 
-	if [ ! -f "${file}" ]; then
-		echo ""
+	if [ ! -f "${file}" ]
+	then
 		echo "It was not possible to find the environment-descriptor for ${LXC_ENVIRONMENT}."
 
 		exit "${LIFERAY_COMMON_EXIT_CODE_BAD}"


### PR DESCRIPTION
[SRE-6066](https://liferay.atlassian.net/browse/SRE-6066)
Changed after https://github.com/brianchandotcom/liferay-docker/pull/660#issuecomment-2269255072

>  5.) Please send me a link to a before and after Dockerfile of BOTH paths.

Previously, the values for the liferay image and the hotfix retrieved from:
- https://github.com/liferay/liferay-lxc/blob/7.4-next/liferay/gradle.properties#L11
- https://github.com/liferay/liferay-lxc/blob/7.4-next/liferay/Dockerfile.ext#L23

from the respective `quarterly-version` branches on the LXC repository.

On the master branch (which will be our single branch), those files contain placeholders instead:
- https://github.com/liferay/liferay-lxc/blob/master/liferay/gradle.properties#L11
- https://github.com/liferay/liferay-lxc/blob/master/liferay/Dockerfile.ext#L23

And the values for those placeholders can be found on `${SPINNER_LIFERAY_LXC_REPOSITORY_DIR}/automation/environment-descriptors/${LXC_ENVIRONMENT}.json`. E.g. for x1e4prd:
- https://github.com/liferay/liferay-lxc/blob/master/automation/environment-descriptors/x1e4prd.json