### PR TITLE
LCD-42405 Include Vary: Origin in all CORS responses to prevent CDN cache issues

### DIFF
--- a/templates/caddy/resources/etc/caddy/Caddyfile
+++ b/templates/caddy/resources/etc/caddy/Caddyfile
@@ -14,6 +14,7 @@
 	header {
 		Access-Control-Allow-Headers *
 		Access-Control-Allow-Methods "GET,OPTIONS,POST"
+        Vary "Origin"
 	}
 
 	import /etc/caddy.d/*

--- a/templates/caddy/resources/usr/local/bin/liferay_caddy_entrypoint.sh
+++ b/templates/caddy/resources/usr/local/bin/liferay_caddy_entrypoint.sh
@@ -15,7 +15,6 @@ function main {
 		cat >> /etc/caddy.d/liferay_caddy_file << EOF
 @origin${url} header Origin ${url}
 header @origin${url} Access-Control-Allow-Origin "${url}"
-header @origin${url} Vary Origin
 EOF
 	done
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LCD-42405

This updates the Caddy server configuraiton to follow the approach specified here: 

https://fetch.spec.whatwg.org/#cors-protocol-and-http-caches

This should fix the problems that customers are experiencing with missing CORS headers