### PR TITLE
LPD-43638 2024.q4.6

### DIFF
--- a/bundles.yml
+++ b/bundles.yml
@@ -765,6 +765,8 @@ quarterly:
     2024.q4.3:
     2024.q4.4:
     2024.q4.5:
+    2024.q4.6:
+        bundle_url: releases-cdn.liferay.com/dxp/2024.q4.6/liferay-dxp-tomcat-2024.q4.6-1738857376.7z
         latest: true
 snapshot:
     snapshot-master:


### PR DESCRIPTION
https://liferay.atlassian.net/issues/LPD-43638

Explicitly setting the URL to point to the correct link after a previously uploaded bundle was reverted due to a bug. 
(Reference: [IT-6390](https://liferay.atlassian.net/browse/IT-6390))

cc @natocesarrego